### PR TITLE
Fix review form element view

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -517,7 +517,8 @@ class JournalReviewFormElementSerializer(TransporterSerializer):
             "checkboxes": "text",  # Concat multiselect checks to string
             "checkbox": "check",
             "check": "check",
-            "radio_buttons": "select"
+            "radio_buttons": "select",
+            "select": "select"
         }
         sentence_terminators = re.compile("\\.|\\?|!")
 

--- a/serializers.py
+++ b/serializers.py
@@ -525,7 +525,7 @@ class JournalReviewFormElementSerializer(TransporterSerializer):
     question = CharField(source="name")
     help_text = CharField(**OPT_STR_FIELD)
     type = CharField(source="kind")
-    responses = ListField(source="choices", child=CharField(), **OPT_FIELD)
+    responses = ListField(source="choices", child=CharField(**OPT_STR_FIELD), **OPT_FIELD)
     required = BooleanField(default=False, **OPT_FIELD)
     sequence = IntegerField(source="order", default=0, **OPT_FIELD)
     width = CharField(default='large-12 columns', **OPT_STR_FIELD)

--- a/views.py
+++ b/views.py
@@ -82,6 +82,8 @@ class JournalReviewFormElementViewSet(TransporterViewSet):
     queryset = ReviewFormElement.objects.all()
     serializer_class = serializers.JournalReviewFormElementSerializer
 
+    def get_queryset(self):
+        return self.queryset.filter(reviewform__pk=self.kwargs["parent_lookup_review_form__id"])
 
 class JournalRoleViewSet(TransporterViewSet):
     queryset = AccountRole.objects.all()


### PR DESCRIPTION
Fixes so the ReviewFormElement view of the API works correctly and add a mapping for an element type that was missing.  Once the view was fixed I got a much more helpful error message in the log that indicates why certain reviewformelements are not importing correctly.