### PR TITLE
Pubd 1077 fix westjem data errors

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -24,6 +24,7 @@ from core.models import Account, AccountRole, Country, File, Galley, Interest, R
 from utils.models import LogEntry
 from identifiers.models import Identifier
 from core import files
+from utils import setting_handler
 import re
 
 OPT_STR_FIELD = {"required": False, "allow_null": True, "allow_blank": True}
@@ -433,13 +434,15 @@ class JournalSerializer(TransporterSerializer):
             "title": "name",
             "description": "description",
             "online_issn": "issn",
-            "print_issn": "print_issn"
+            "print_issn": "print_issn",
+            "copyright_notice": "copyright_notice"
         }
         fields = tuple(field_map.keys())
         setting_values = (
             "name",
             "issn",
-            "print_issn"
+            "print_issn",
+            "copyright_notice"
         )
         attachments = {
             "header_file": "header_image",
@@ -451,10 +454,20 @@ class JournalSerializer(TransporterSerializer):
     description = CharField(**OPT_STR_FIELD)
     online_issn = CharField(source="issn", **OPT_STR_FIELD)
     print_issn = CharField(**OPT_STR_FIELD)
+    copyright_notice = CharField(**OPT_STR_FIELD)
 
     def post_process(self, journal: Journal, data: dict) -> None:
         # TODO - Need to look into importing article images if they exist
         journal.disable_article_images = True
+
+        # copyright_notice property is set in Serializer.create method.
+        # The other settings have setters defined in the Journal model
+        # that create this settings object but it's not defined for copyright
+        if hasattr(journal, "copyright_notice"):
+            setting_handler.save_setting('general',
+                                         'copyright_notice',
+                                         journal,
+                                         journal.copyright_notice)
 
         # Mimic regular journal creation process
         journal.setup_directory()

--- a/serializers.py
+++ b/serializers.py
@@ -1451,7 +1451,12 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
         if not data.get("date_due"):
             data["date_due"] = data.get("date_completed") or data.get("date_assigned")
 
-        data["date_due"] = datetime.strptime(data["date_due"], '%Y-%m-%dT%H:%M:%S%z').strftime('%Y-%m-%d')
+        # if due date received is a datetime convert to just date
+        # else just assume it's a date and let the system handle it
+        try:
+            data["date_due"] = datetime.strptime(data["date_due"], '%Y-%m-%dT%H:%M:%S%z').strftime('%Y-%m-%d')
+        except ValueError:
+            pass
 
         # Extract comments from list, if needed
         comment = data.get("comments")

--- a/serializers.py
+++ b/serializers.py
@@ -1469,6 +1469,12 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
             data["decision"] = self.Meta.decision_map.get(normalized_decision) or data.get("decision")
 
     def post_process(self, review_assignment: ReviewAssignment, data: dict):
+        # date_requested field default is 'auto_now_add' which overwrites this date
+        date_requested = data.get("date_requested", None)
+        if date_requested:
+            review_assignment.date_requested = date_requested
+            review_assignment.save()
+
         # Build review rating, which comes in as a value between 0-100
         quality = self.initial_data.get("quality")
         if quality and review_assignment.editor:

--- a/tests.py
+++ b/tests.py
@@ -1,14 +1,32 @@
 from django.test import TestCase
 
-from .serializers import UserSerializer, JournalArticleRoundAssignmentSerializer
-from .views import UserViewSet, JournalArticleRoundViewSet
+from .serializers import UserSerializer, JournalArticleRoundAssignmentSerializer, JournalSerializer
+from .views import UserViewSet, JournalArticleRoundViewSet, JournalViewSet
 
 from core.models import Account, Interest
 from review.models import ReviewRound
 from utils.testing import helpers
+from utils import setting_handler
 
 import datetime
 from django.utils import timezone
+
+class TestJournalSerializerTest(TestCase):
+
+    def setUp(self):
+        self.journal, _ = helpers.create_journals()
+
+    def test_copyright_notice(self):
+        notice = 'This is the copyright notice'
+        data = {"path": "testj", "title": "Test Journal", "copyright_notice": notice}
+        s = JournalSerializer(data=data)
+        s.context["view"] = JournalViewSet(kwargs={})
+
+        self.assertTrue(s.is_valid())
+
+        j = s.save()
+
+        self.assertEqual(setting_handler.get_setting('general', 'copyright_notice', j).value, notice)
 
 class AssignmentSerializerTest(TestCase):
 


### PR DESCRIPTION
I closed two previous PRs that had this code but without tests.  I combined the PRs and added tests for both.

- Set date_requested in post_process else it gets overwritten by db default
- Allow date_due to accept either date or datetime (the field is actually a date not datetime but this plugin originally only accepted datetime so just support both so we don't break anything)
- Accept copyright_notice for journals
- Test for all of above