### PR TITLE
Pubd 1077 westjem errors part 2

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -1,7 +1,7 @@
 import json
 import textwrap
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from bs4 import BeautifulSoup
 
 from django.db.models import Model, Q
@@ -1457,9 +1457,15 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
         return (rating.rating * 10) if rating else None
 
     def before_validation(self, data: dict):
+
         # Attempt to derive date_due
         if not data.get("date_due"):
-            data["date_due"] = data.get("date_completed") or data.get("date_assigned")
+            if data.get("date_completed"):
+                data["date_due"] = data.get("date_completed")
+            elif data.get("date_assigned"):
+                data["date_due"] = data.get("date_assigned")
+            else:
+                data["date_due"] = date.today().strftime('%Y-%m-%d')
 
         # if due date received is a datetime convert to just date
         # else just assume it's a date and let the system handle it

--- a/serializers.py
+++ b/serializers.py
@@ -1152,7 +1152,7 @@ class JournalArticleAuthorSerializer(UserSerializer):
             self.article.authors.add(record.author)
 
             # Set order
-            ArticleAuthorOrder.objects.create(
+            ArticleAuthorOrder.objects.get_or_create(
                 article=self.article,
                 author=record.author,
                 order=self.initial_data.get("sequence", self.article.authors.count() + 1)

--- a/tests.py
+++ b/tests.py
@@ -80,6 +80,11 @@ class AssignmentSerializerTest(TestCase):
         self.assertEqual(a.date_requested.strftime(dtformat), date_assigned)
         self.assertEqual(a.date_due.strftime("%Y-%m-%d"), "2023-01-01")
 
+    def test_no_dates(self):
+        s = self.validate_serializer({})
+        a = s.save()
+        self.assertEqual(a.date_due.strftime("%Y-%m-%d"), datetime.date.today().strftime('%Y-%m-%d'))
+
 class UserSerializerTest(TestCase):
     """
     Test UserSerializer


### PR DESCRIPTION
Fix errors identified in latest westjem migration.

1. If no dates are provided make the due date today. 
2. fix uncaught exception when creating duplicate editor assignments -- just return the existing assignment
3. fix uncaught exception after creating a duplicate author ordering -- don't create a duplicate in the first place