### PR TITLE
Pubd 1077 westjem part3

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -1221,7 +1221,8 @@ class JournalArticleFileSerializer(TransporterSerializer):
             file_to_be_replaced_pk = self.initial_data.get("parent_target_record_key").split(":")[-1]
             file_to_be_replaced = File.objects.get(pk=file_to_be_replaced_pk)
             if file_to_be_replaced:
-                # TODO: Is this the best way to do this? Is "overwriting" correct?
+                # use the overwrite_file method for creating a file history
+                # but maintain the file_name/label from OJS
                 file = files.overwrite_file(raw_file, file_to_be_replaced, ('articles', self.article.pk))
                 file.label = label
                 file.save()

--- a/serializers.py
+++ b/serializers.py
@@ -1155,7 +1155,7 @@ class JournalArticleAuthorSerializer(UserSerializer):
             ArticleAuthorOrder.objects.get_or_create(
                 article=self.article,
                 author=record.author,
-                order=self.initial_data.get("sequence", self.article.authors.count() + 1)
+                defaults={"order": self.initial_data.get("sequence", self.article.authors.count() + 1)}
             )
 
             # Primary contact is not a model attr, so look it up in the initial (unvalidated) data.

--- a/serializers.py
+++ b/serializers.py
@@ -1213,6 +1213,9 @@ class JournalArticleFileSerializer(TransporterSerializer):
 
         raw_file = data.pop("file")
 
+        label_fields = ["label", "filename", "file_name", "original_filename"]
+        label = [self.initial_data.get(field) for field in label_fields if self.initial_data.get(field)][0]
+
         # If the file has a parent, then it belongs in the file history
         if self.initial_data.get("parent_target_record_key"):
             file_to_be_replaced_pk = self.initial_data.get("parent_target_record_key").split(":")[-1]
@@ -1220,9 +1223,9 @@ class JournalArticleFileSerializer(TransporterSerializer):
             if file_to_be_replaced:
                 # TODO: Is this the best way to do this? Is "overwriting" correct?
                 file = files.overwrite_file(raw_file, file_to_be_replaced, ('articles', self.article.pk))
+                file.label = label
+                file.save()
         else:
-            label_fields = ["label", "filename", "file_name", "original_filename"]
-            label = [self.initial_data.get(field) for field in label_fields if self.initial_data.get(field)][0]
             file = files.save_file_to_article(raw_file,
                                               self.article,
                                               None,

--- a/serializers.py
+++ b/serializers.py
@@ -1178,7 +1178,7 @@ class JournalArticleAuthorSerializer(UserSerializer):
 
 class JournalArticleFileSerializer(TransporterSerializer):
     """
-    Transporter serializer for article files (/journals/{id}/arti8cles/{id}/files).
+    Transporter serializer for article files (/journals/{id}/articles/{id}/files).
 
     Maps to core.models.File and attaches to appropriate Article. Also handles building
     file history if parent file is defined.
@@ -1222,7 +1222,7 @@ class JournalArticleFileSerializer(TransporterSerializer):
                 file = files.overwrite_file(raw_file, file_to_be_replaced, ('articles', self.article.pk))
         else:
             label_fields = ["label", "filename", "file_name", "original_filename"]
-            label = [data.get(field) for field in label_fields if data.get(field)][0]
+            label = [self.initial_data.get(field) for field in label_fields if self.initial_data.get(field)][0]
             file = files.save_file_to_article(raw_file,
                                               self.article,
                                               None,

--- a/serializers.py
+++ b/serializers.py
@@ -1408,6 +1408,11 @@ class JournalArticleRoundSerializer(TransporterSerializer):
                                            element=workflow_element,
                                            timestamp=(review_round.article.date_submitted or review_round.date_started))
 
+        # override auto_now_add for date_started
+        date_started = data.get("date_started", None)
+        if date_started:
+            review_round.date_started = date_started
+            review_round.save()
 
 class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
     """

--- a/serializers.py
+++ b/serializers.py
@@ -392,6 +392,7 @@ class UserSerializer(TransporterSerializer):
             # save this user to a variable and return it after post_process
             user_to_return = existing
         except Account.DoesNotExist:
+            validated_data["is_active"] = True
             user_to_return = super().create(validated_data)
         # because we've overridden the create method, we need to call the
         # post_process method manually

--- a/serializers.py
+++ b/serializers.py
@@ -1346,7 +1346,7 @@ class JournalArticleRevisionRequestSerializer(TransporterSerializer):
             "rejected": None,
             "declined": None,
             "decline": None,
-            "resubmit": None,
+            "resubmit": "major_revisions",
             "major_revisions": "major_revisions",
             "minor_revisions": "minor_revisions",
             "revisions": "minor_revisions",

--- a/serializers.py
+++ b/serializers.py
@@ -938,6 +938,12 @@ class JournalArticleSerializer(TransporterSerializer):
 
             article.save()
 
+        # override auto_now_add for date_started
+        date_started = data.get("date_started", None)
+        if date_started:
+            article.date_started = date_started
+            article.save()
+
         # Assign custom field values
         self.assign_custom_field_values(article)
 

--- a/serializers.py
+++ b/serializers.py
@@ -1046,7 +1046,8 @@ class JournalArticleEditorSerializer(TransporterSerializer):
             "notified": "notified",
             "date_notified": "assigned",
             "editor_type": "editor_type",
-            "editor_id": "editor_id"
+            "editor_id": "editor_id",
+            "is_editor": "is_editor"
         }
         foreign_keys = {
             "editor": "editor_id"
@@ -1055,19 +1056,18 @@ class JournalArticleEditorSerializer(TransporterSerializer):
 
     notified = BooleanField(**OPT_FIELD)
     date_notified = DateTimeField(source="assigned", **OPT_FIELD)
-    editor_type = CharField(default="editor", **OPT_STR_FIELD)
+    editor_type = CharField(**OPT_STR_FIELD)
 
     editor_id = IntegerField()
+    is_editor = BooleanField(**OPT_FIELD)
 
     def pre_process(self, data: dict):
         data["notified"] = bool(data.get("assigned"))
         data["assigned"] = data.get("assigned") or self.article.date_submitted or datetime.now()
+        is_editor = data.pop("is_editor", True)
+
         if not data.get("editor_type"):
-            role = Role.objects.filter(slug="editor")
-            if role:
-                user = Account.objects.get(pk=data.get("editor_id"))
-                has_editor_role = AccountRole.objects.filter(user=user, role=role).exists()
-                data["editor_type"] = "editor" if has_editor_role else "section-editor"
+            data["editor_type"] = "editor" if is_editor else "section-editor"
 
     # get_or_create doesn't work properly finding items that use unique_together
     # recommended solution is to pass data with only unique_together items and

--- a/serializers.py
+++ b/serializers.py
@@ -1563,11 +1563,10 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
         if supplementary_file_ids and len(supplementary_file_ids):
             already_added = review_assignment.review_round.review_files.filter(pk__in=supplementary_file_ids)
             already_added_pks = [file.pk for file in already_added]
-            to_add = set(already_added_pks) - set(supplementary_file_ids)
+            to_add = set(supplementary_file_ids) - set(already_added_pks)
             for file_id in to_add:
                 file = File.objects.get(pk=file_id)
                 review_assignment.review_round.review_files.add(file)
-
 
 class JournalArticleRoundAssignmentResponseSerializer(TransporterSerializer):
     """

--- a/tests.py
+++ b/tests.py
@@ -127,6 +127,19 @@ class EditorAssignmentSerializerTest(TestCase):
         s.validated_data['article_id'] = self.article.pk
         return s
 
+    def test_is_editor(self):
+        dtformat = '%Y-%m-%dT%H:%M:%S%z'
+
+        assigned = datetime.datetime(2023, 1, 1, tzinfo=timezone.get_current_timezone()).strftime(dtformat)
+        data = {'editor_id': self.user.pk, 'date_notified': assigned, 'is_editor': False, 'notified': True}
+        a = self.validate_serializer(data).save()
+
+        self.assertEqual(a.editor.pk, self.user.pk)
+        self.assertEqual(a.article.pk, self.article.pk)
+        self.assertEqual(a.editor_type, 'section-editor')
+        self.assertEqual(a.notified, True)
+        self.assertEqual(a.assigned.strftime(dtformat), assigned)
+
     def test_duplicates(self):
         dtformat = '%Y-%m-%dT%H:%M:%S%z'
 

--- a/tests.py
+++ b/tests.py
@@ -41,6 +41,29 @@ class TestJournalSerializerTest(TestCase):
 
         self.assertEqual(setting_handler.get_setting('general', 'copyright_notice', j).value, notice)
 
+class ReviewRoundASerializerTest(TestCase):
+    def setUp(self):
+        self.journal, _ = helpers.create_journals()
+        self.article = helpers.create_article(self.journal)
+
+    def validate_serializer(self, data):
+        s = JournalArticleRoundSerializer(data=data)
+        s.context["view"] = JournalArticleRoundViewSet(kwargs={})
+
+        self.assertTrue(s.is_valid())
+        # typically this is set by the view but since we're
+        # circumventing that just set it manually
+        s.validated_data['article_id'] = self.article.pk
+        return s
+
+    def test_date_started(self):
+        date_started = "2022-03-28T18:03:34+0000"
+        data = {'round': 1, 'date': date_started}
+        s = self.validate_serializer(data)
+        round = s.save()
+
+        self.assertEqual(round.date_started.strftime('%Y-%m-%dT%H:%M:%S%z'), date_started)
+
 class ReviewAssignmentSerializerTest(TestCase):
 
     def setUp(self):

--- a/tests.py
+++ b/tests.py
@@ -122,6 +122,26 @@ class EditorAssignmentSerializerTest(TestCase):
         self.assertEqual(a1.notified, True)
         self.assertEqual(a1.assigned.strftime(dtformat), date_assigned1)
 
+class ArticleSerializerTest(TestCase):
+
+    def setUp(self):
+        self.journal, _ = helpers.create_journals()
+
+    def validate_serializer(self, data):
+        s = JournalArticleSerializer(data=data)
+        s.context["view"] = JournalArticleViewSet(kwargs={})
+        s.journal = self.journal
+        self.assertTrue(s.is_valid())
+        return s
+
+    def test_date_started(self):
+        date_started = "2022-03-28T18:03:34+0000"
+        data = {'title': "Title 1", 'date_started': date_started}
+        s = self.validate_serializer(data)
+        article = s.save()
+
+        self.assertEqual(article.date_started.strftime('%Y-%m-%dT%H:%M:%S%z'), date_started)
+
 class AuthorAssignmentSerializerTest(TestCase):
 
     def setUp(self):

--- a/tests.py
+++ b/tests.py
@@ -321,6 +321,29 @@ class ArticleFileSerializerTest(TestCase):
 
         self.assertEqual(f.label, data["file_name"])
 
+    def test_file_history_label(self):
+        parent_file = File.objects.create(article_id=self.article.pk,
+                                          mime_type="application/pdf",
+                                          original_filename="parent_file.pdf",
+                                          uuid_filename="0000.pdf",
+                                          label="Parent File Label",
+                                          sequence=1)
+
+        pdf_file = SimpleUploadedFile("test.pdf", b"\x00\x01\x02\x03")
+        data = {"file": pdf_file,
+                "file_name":"file_name.pdf",
+                "file_type":"application/pdf",
+                "original_filename":"original_filename.pdf",
+                "date_uploaded":"2022-03-28T17:50:05+00:00",
+                "type":"submission/original",
+                "round":1,
+                "parent_target_record_key":f"ArticleFile:{self.article.pk}:{parent_file.pk}"}
+
+        s = self.validate_serializer(data)
+        f = s.save()
+
+        self.assertEqual(f.label, data["file_name"])
+
 class UserSerializerTest(TestCase):
     """
     Test UserSerializer

--- a/tests.py
+++ b/tests.py
@@ -390,6 +390,7 @@ class UserSerializerTest(TestCase):
         self.assertEqual(user.email, valid_user_data['email'])
         self.assertEqual(user.first_name, valid_user_data['first_name'])
         self.assertEqual(user.last_name, valid_user_data['last_name'])
+        self.assertTrue(user.is_active)
 
     def test_user_serializer_invalid_user_missing_email(self):
         user_data = {"username": "invalid_user", "email": "", "first_name": "Sam", "last_name": "Sam"}

--- a/tests.py
+++ b/tests.py
@@ -141,13 +141,15 @@ class AuthorAssignmentSerializerTest(TestCase):
         return s
 
     def test_multiple_objects(self):
-        data = {'user_id': self.user.pk, 'email': self.user.email, 'first_name': 'Author', 'last_name': 'Test', 'sequence': 1}
+        data = {'user_id': self.user.pk, 'email': self.user.email, 'first_name': 'Author', 'last_name': 'Test', 'sequence': 2}
         s = self.validate_serializer(data)
         a1 = s.save()
+        data['sequence'] = 3
         s = self.validate_serializer(data)
         a2 = s.save()
 
-        self.assertEqual(ArticleAuthorOrder.objects.filter(article=self.article, author=self.user, order=1).count(), 1)
+        self.assertEqual(ArticleAuthorOrder.objects.filter(article=self.article, author=self.user).count(), 1)
+        self.assertEqual(ArticleAuthorOrder.objects.get(article=self.article, author=self.user).order, 2)
 
 class UserSerializerTest(TestCase):
     """


### PR DESCRIPTION
- Make sure only one author ordering is created for each article/author pair even if there are duplicates with different orders (order from first created will be maintained)
- Make sure Article.date_started and ReviewRound.date_started dates are transferred and not overwritten by auto_now_add 
- Use is_editor field to determine if an editor assignment should be a section-editor or editor (remove some role-based code that was never working anyway)
- If a review assignment has been declined fill the date_declined not date_accepted field
- If a review assignment has been cancelled mark it "withdrawn" in janeway
- Fix code where label should be assigned to field file_name if it exists
- Make sure indicated supplementary files are added to the review assignment/review round
- Override default janeway behavior to set file history labels to the file_name field from OJS
- Create RevisionRequest for items with decision "resubmit"
- Make new users active by default