### PR TITLE
add authentication transporter views

### DIFF
--- a/test_views.py
+++ b/test_views.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.core.management import call_command
+from utils.testing import helpers
+import json
+
+class TestViews(TestCase):
+    def setUp(self):
+        self.press = helpers.create_press()
+        self.press.domain = "testserver"
+        self.press.save()
+        self.user = helpers.create_user("a@b.edu")
+        self.user.is_active = True
+        self.user.is_staff = True
+        self.user.save()
+        self.journal1, self.journal2 = helpers.create_journals()
+        # we have to call install for the views to be available
+        call_command('install_plugins', 'journal_transporter')
+
+    def test_no_authentication(self):
+        response = self.client.get('/plugins/journal-transporter-plugin-for-janeway-14/journals/')
+        self.assertEqual(response.status_code, 403)
+        j = json.loads(response.content)
+        self.assertEqual(j["detail"], "Authentication credentials were not provided.")
+
+    def test_authentication(self):
+        self.client.force_login(user=self.user)
+        response = self.client.get('/plugins/journal-transporter-plugin-for-janeway-14/journals/')
+        self.assertEqual(response.status_code, 200)
+        j = json.loads(response.content)
+        self.assertEqual(j["count"], 2)
+        self.assertEqual(len(j["results"]), 2)

--- a/views.py
+++ b/views.py
@@ -2,6 +2,8 @@ from django.http import HttpResponse, Http404
 
 from rest_framework import viewsets, parsers
 from plugins.journal_transporter.parsers import MultiPartJSONParser
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from rest_framework.permissions import IsAuthenticated
 
 from plugins.journal_transporter import serializers
 
@@ -58,6 +60,8 @@ def manager(request):
 class TransporterViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     http_method_names = ['get', 'post']
     parser_classes = [parsers.JSONParser, MultiPartJSONParser]
+    authentication_classes = [SessionAuthentication, BasicAuthentication]
+    permission_classes = [IsAuthenticated]
 
     def delete(self, _request, *_args, **_kwargs):
         """Deleting resources through this plugin is not allowed."""


### PR DESCRIPTION
- Authentication directly in plugin so it doesn't affect the built-in janeway API
- Add tests so we know it's working (note users have to be staff to access)