### PR TITLE
set default form and import assignment comments

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -1570,11 +1570,16 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
                     file = File.objects.get(pk=file_id)
                     review_assignment.review_round.review_files.add(file)
 
+        # if no form is set for this review assignment set to the default form that
+        # is automatically created for every journal.
         default_form = ReviewForm.objects.get(journal=review_assignment.article.journal, name="Default Form")
         form_element = default_form.elements.all()[0]
         if not review_assignment.form:
             review_assignment.form = default_form
 
+        # OJS has an option to add reviewer comments that aren't in a form
+        # Janeway only has a one field for "comments_for_editor"
+        # For author comments and additional editor comments add answers associated with the default form
         for c in self.comments:
             if not c["visible_to_author"] and (not review_assignment.comments_for_editor or len(review_assignment.comments_for_editor) == 0):
                 review_assignment.comments_for_editor = c["comments"]
@@ -1583,6 +1588,7 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
                                                                original_element=form_element,
                                                                author_can_see=c["visible_to_author"],
                                                                answer=c["comments"])
+                # you have to do this to make a "FrozenField" else there can be display problems
                 form_element.snapshot(answer)
 
         review_assignment.save()

--- a/serializers.py
+++ b/serializers.py
@@ -610,7 +610,6 @@ class JournalReviewFormElementSerializer(TransporterSerializer):
         form = ReviewForm.objects.get(pk=self.review_form_id)
         if form: form.elements.add(obj)
 
-
 class JournalRoleSerializer(TransporterSerializer):
     """
     Transporter serializer for user roles (/journals/{id}/roles/{user_id}/)
@@ -1512,9 +1511,7 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
         except ValueError:
             pass
 
-        # Extract comments from list, if needed
-        comment = data.get("comments")
-        data["comments"] = comment[0]["comments"] if isinstance(comment, list) and len(comment) > 0 else None
+        self.comments = data.pop("comments", [])
 
     def pre_process(self, data: dict):
         is_declined = data.pop("is_declined", False)
@@ -1572,6 +1569,23 @@ class JournalArticleRoundAssignmentSerializer(TransporterSerializer):
                 if File.objects.filter(pk=file_id).exists():
                     file = File.objects.get(pk=file_id)
                     review_assignment.review_round.review_files.add(file)
+
+        default_form = ReviewForm.objects.get(journal=review_assignment.article.journal, name="Default Form")
+        form_element = default_form.elements.all()[0]
+        if not review_assignment.form:
+            review_assignment.form = default_form
+
+        for c in self.comments:
+            if not c["visible_to_author"] and (not review_assignment.comments_for_editor or len(review_assignment.comments_for_editor) == 0):
+                review_assignment.comments_for_editor = c["comments"]
+            else:
+                answer = ReviewAssignmentAnswer.objects.create(assignment=review_assignment,
+                                                               original_element=form_element,
+                                                               author_can_see=c["visible_to_author"],
+                                                               answer=c["comments"])
+                form_element.snapshot(answer)
+
+        review_assignment.save()
 
 class JournalArticleRoundAssignmentResponseSerializer(TransporterSerializer):
     """

--- a/tests.py
+++ b/tests.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-import re
+import re, json
 
 DATETIME1 = datetime.datetime(2023, 1, 1, tzinfo=timezone.get_current_timezone())
 DATETIME2 = datetime.datetime(2023, 2, 2, tzinfo=timezone.get_current_timezone())
@@ -223,6 +223,15 @@ class ReviewAssignmentSerializerTest(TestCase):
 
         self.assertEquals(a.review_round.review_files.count(), 2)
 
+    def test_review_comments(self):
+        data = {"comments": [{"comments": "Author Comment 1", "visible_to_author": True},
+                             {"comments": "Author Comment 2", "visible_to_author": True},
+                             {"comments": "Editor <b>Comment</b> 1", "visible_to_author": False},
+                             {"comments": "Editor Comment 2", "visible_to_author": False}]}
+        s = self.validate_serializer(data)
+        a = s.save()
+        self.assertEqual(a.comments_for_editor, "Editor <b>Comment</b> 1")
+        self.assertEqual(a.reviewassignmentanswer_set.count(), 3)
 
 class EditorAssignmentSerializerTest(TestCase):
 
@@ -467,3 +476,4 @@ class UserSerializerTest(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn('last_name', serializer.errors)
+


### PR DESCRIPTION
- When there is no form set the form to the default form for the journal
- Import the review assignment comments as review assignment answers
- First editor-only comment goes to comments_for_editor after just take them on as review assignment answers that the author cannot see.
